### PR TITLE
Feat/#20/exam config

### DIFF
--- a/src/apis/database.types.ts
+++ b/src/apis/database.types.ts
@@ -154,6 +154,21 @@ export type Database = {
         };
         Relationships: [];
       };
+      exam_expose_option: {
+        Row: {
+          code: string;
+          name: string;
+        };
+        Insert: {
+          code: string;
+          name: string;
+        };
+        Update: {
+          code?: string;
+          name?: string;
+        };
+        Relationships: [];
+      };
       series: {
         Row: {
           category: string;

--- a/src/apis/exposeOption.ts
+++ b/src/apis/exposeOption.ts
@@ -1,0 +1,9 @@
+import supabase from '@apis/supabase.ts';
+
+export const getExamExposeOptions = async () => {
+  const { data, error } = await supabase.from('exam_expose_option').select();
+
+  if (error) throw error;
+
+  return data;
+};

--- a/src/components/modal/index.test.tsx
+++ b/src/components/modal/index.test.tsx
@@ -1,0 +1,9 @@
+import { describe, test } from 'vitest';
+
+describe('Modal Test', () => {
+  test('renders title, contents with given props', () => {});
+  test('renders "취소" and "확인" button', () => {});
+  test('when clicks "취소" button, props.onCloseModal executes', () => {});
+  test('when clicks backdrop, props.onCloseModal executes', () => {});
+  test('when clicks "확인" button, props.onClickConfirm executes', () => {});
+});

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -57,7 +57,7 @@ function Modal({
               <button
                 type='button'
                 onClick={handleClickConfirm}
-                className='inline-flex w-full justify-center rounded-lg bg-secondary px-3 py-2 text-lg font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary mobile:text-base'
+                className='col-start-1 mt-3 inline-flex w-full justify-center rounded-lg bg-secondary px-3 py-2 text-lg font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary mobile:text-base'
               >
                 확인
               </button>

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,0 +1,72 @@
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/react';
+
+type ModalProps = {
+  title?: string;
+  children: React.ReactNode;
+  isOpen: boolean;
+  onCloseModal: () => void;
+  onClickConfirm: () => void;
+};
+
+function Modal({
+  title,
+  children,
+  isOpen,
+  onCloseModal,
+  onClickConfirm,
+}: ModalProps) {
+  const handleCloseModal = () => onCloseModal();
+  const handleClickConfirm = () => onClickConfirm();
+  return (
+    <Dialog open={isOpen} onClose={handleCloseModal} className='relative z-10'>
+      <DialogBackdrop
+        transition
+        className='fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in'
+      />
+
+      <div className='fixed inset-0 z-10 w-screen overflow-y-auto'>
+        <div className='flex min-h-full items-center justify-center p-0 text-center'>
+          <DialogPanel
+            transition
+            className='relative w-full max-w-lg overflow-hidden rounded-xl bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all data-[closed]:translate-y-0 data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in mobile:p-6'
+          >
+            <div className='mt-3 text-center'>
+              {title && (
+                <DialogTitle
+                  as='h3'
+                  className='text-3xl font-semibold text-gray-900 mobile:text-xl'
+                >
+                  {title}
+                </DialogTitle>
+              )}
+              {children}
+            </div>
+            <div className='my-3 flex items-center justify-center space-x-3'>
+              <button
+                type='button'
+                onClick={handleCloseModal}
+                className='col-start-1 mt-3 inline-flex w-full justify-center rounded-lg bg-white px-3 py-2 text-lg font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 mobile:text-base'
+              >
+                취소
+              </button>
+              <button
+                type='button'
+                onClick={handleClickConfirm}
+                className='inline-flex w-full justify-center rounded-lg bg-secondary px-3 py-2 text-lg font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary mobile:text-base'
+              >
+                확인
+              </button>
+            </div>
+          </DialogPanel>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+export default Modal;

--- a/src/features/exam/components/examConfigModal/exposeSelect/index.test.tsx
+++ b/src/features/exam/components/examConfigModal/exposeSelect/index.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest';
+
+describe('ExposeSelect Test', () => {
+  test('its listbox renders options with exam expose option data', () => {});
+});

--- a/src/features/exam/components/examConfigModal/exposeSelect/index.tsx
+++ b/src/features/exam/components/examConfigModal/exposeSelect/index.tsx
@@ -1,0 +1,38 @@
+import CommonCombobox from '@components/commonCombobox';
+import { useExamConfigStore } from '@features/exam/store/examConfigStore.ts';
+import { useShallow } from 'zustand/react/shallow';
+import { useQuery } from '@tanstack/react-query';
+import { getExamExposeOptions } from '@apis/exposeOption.ts';
+import Loader from '@components/Loader.tsx';
+
+function ExposeSelect() {
+  const { name, code } = useExamConfigStore(
+    useShallow(state => state.exposeOption),
+  );
+  const setExposeOption = useExamConfigStore(state => state.setExposeOption);
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['exposeOption'],
+    queryFn: getExamExposeOptions,
+  });
+
+  if (isPending) return <Loader />;
+  if (isError) return <div>데이터 조회에 실패했습니다.</div>;
+
+  const items = data.map(({ name, code }) => ({ name, value: code, id: code }));
+
+  return (
+    <div className='flex items-center text-left'>
+      <CommonCombobox
+        label={'표시'}
+        items={items}
+        selectedItem={{ name, value: code, id: code }}
+        onChangeCombobox={({ name, value }) =>
+          setExposeOption({ name, code: value })
+        }
+      />
+    </div>
+  );
+}
+
+export default ExposeSelect;

--- a/src/features/exam/components/examConfigModal/index.test.tsx
+++ b/src/features/exam/components/examConfigModal/index.test.tsx
@@ -1,0 +1,11 @@
+import { describe, test } from 'vitest';
+
+describe('ExamConfigModal rendering test', () => {
+  test('renders "제한시간" input with default value 30', () => {});
+  test('renders "순서" select with default value "기본 순"', () => {});
+  test('renders "표시" select with default value "장절"', () => {});
+});
+
+describe('ExamConfigModal operation test', () => {
+  test('when clicks "확인" button, modal shows off and routes to "/exam"');
+});

--- a/src/features/exam/components/examConfigModal/index.tsx
+++ b/src/features/exam/components/examConfigModal/index.tsx
@@ -1,0 +1,41 @@
+import Modal from '@components/modal';
+import TimeLimit from '@features/exam/components/examConfigModal/timelimit';
+import ExposeSelect from '@features/exam/components/examConfigModal/exposeSelect';
+import SortMethodSelect from '@features/exam/components/examConfigModal/sortMethodSelect';
+import { useExamConfigModalStore } from '@features/exam/store/examConfigModalStore.ts';
+import { useNavigate } from 'react-router-dom';
+import { useExamConfigStore } from '@features/exam/store/examConfigStore.ts';
+
+function ExamConfigModal() {
+  const isOpen = useExamConfigModalStore(state => state.isOpen);
+  const setIsOpen = useExamConfigModalStore(state => state.setIsOpen);
+  const navigate = useNavigate();
+  const resetExamConfig = useExamConfigStore(state => state.reset);
+
+  const handleOnCloseModal = () => {
+    setIsOpen(false);
+    resetExamConfig();
+  };
+
+  const handleClickConfirm = () => {
+    setIsOpen(false);
+    void navigate('/exam');
+  };
+
+  return (
+    <Modal
+      title='시험설정'
+      onCloseModal={handleOnCloseModal}
+      isOpen={isOpen}
+      onClickConfirm={handleClickConfirm}
+    >
+      <div className='mx-auto mb-12 mt-10 flex max-w-[200px] flex-col items-start space-y-5'>
+        <TimeLimit />
+        <ExposeSelect />
+        <SortMethodSelect />
+      </div>
+    </Modal>
+  );
+}
+
+export default ExamConfigModal;

--- a/src/features/exam/components/examConfigModal/sortMethodSelect/index.test.tsx
+++ b/src/features/exam/components/examConfigModal/sortMethodSelect/index.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest';
+
+describe('SortMethodSelect Test', () => {
+  test('its listbox renders options with card sort method data', () => {});
+});

--- a/src/features/exam/components/examConfigModal/sortMethodSelect/index.tsx
+++ b/src/features/exam/components/examConfigModal/sortMethodSelect/index.tsx
@@ -1,0 +1,38 @@
+import { useExamConfigStore } from '@features/exam/store/examConfigStore.ts';
+import { useShallow } from 'zustand/react/shallow';
+import CommonCombobox from '@components/commonCombobox';
+import { useQuery } from '@tanstack/react-query';
+import { getCardSortMethod } from '@apis/cardSortMethod.ts';
+import Loader from '@components/Loader.tsx';
+
+function SortMethodSelect() {
+  const { name, code } = useExamConfigStore(
+    useShallow(state => state.sortMethod),
+  );
+  const setSortMethod = useExamConfigStore(state => state.setSortMethod);
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['sortMethod'],
+    queryFn: getCardSortMethod,
+  });
+
+  if (isPending) return <Loader />;
+  if (isError) return <div>데이터 조회에 실패했습니다.</div>;
+
+  const items = data.map(({ name, code }) => ({ name, value: code, id: code }));
+
+  return (
+    <div className='flex items-center text-left'>
+      <CommonCombobox
+        label={'순서'}
+        items={items}
+        selectedItem={{ name, value: code, id: code }}
+        onChangeCombobox={({ name, value }) =>
+          setSortMethod({ name, code: value })
+        }
+      />
+    </div>
+  );
+}
+
+export default SortMethodSelect;

--- a/src/features/exam/components/examConfigModal/timelimit/index.test.tsx
+++ b/src/features/exam/components/examConfigModal/timelimit/index.test.tsx
@@ -1,0 +1,6 @@
+import { describe, test } from 'vitest';
+
+describe('TimeLimit Test', () => {
+  test('input displays updated value when user types number', () => {});
+  test('input displays updated value when user clicks increase or decrease button', () => {});
+});

--- a/src/features/exam/components/examConfigModal/timelimit/index.tsx
+++ b/src/features/exam/components/examConfigModal/timelimit/index.tsx
@@ -1,0 +1,30 @@
+import {
+  MINUITE,
+  useExamConfigStore,
+} from '@features/exam/store/examConfigStore.ts';
+import { useShallow } from 'zustand/react/shallow';
+
+function TimeLimit() {
+  const time = useExamConfigStore(useShallow(state => state.time / MINUITE));
+  const setTime = useExamConfigStore(state => state.setTime);
+
+  return (
+    <div className='text-left text-[22px] mobile:text-base/4'>
+      <label htmlFor='timelimit' className='block font-semibold text-secondary'>
+        제한시간
+      </label>
+      <div className='mt-2 flex items-center justify-center space-x-2'>
+        <input
+          type='number'
+          id='timelimit'
+          value={time}
+          className='block w-full rounded-md bg-white px-3 py-1.5 text-xl font-medium text-secondary outline outline-1 -outline-offset-2 outline-gray-300 placeholder:text-gray-400 focus:border-[#6b7280] focus:outline-1 focus:-outline-offset-2 focus:outline-gray-300 focus:ring-0 mobile:text-sm'
+          onChange={e => setTime(Number(e.target.value))}
+        />
+        <span>분</span>
+      </div>
+    </div>
+  );
+}
+
+export default TimeLimit;

--- a/src/features/exam/store/examConfigModalStore.ts
+++ b/src/features/exam/store/examConfigModalStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+type ExamConfigModalState = {
+  isOpen: boolean;
+};
+
+type ExamConfigModalAction = {
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+type ExamConfigModalStore = ExamConfigModalState & ExamConfigModalAction;
+
+const initialState: ExamConfigModalState = {
+  isOpen: false,
+};
+
+export const useExamConfigModalStore = create<ExamConfigModalStore>()(set => ({
+  ...initialState,
+  setIsOpen: isOpen => set({ isOpen }),
+}));

--- a/src/features/exam/store/examConfigStore.ts
+++ b/src/features/exam/store/examConfigStore.ts
@@ -1,0 +1,33 @@
+import { CardSortMethod } from '@apis/custom.types.ts';
+import { ExamExposeOption } from '@features/exam/type.ts';
+import { create } from 'zustand';
+
+type ExamConfigState = {
+  time: number;
+  sortMethod: CardSortMethod;
+  exposeOption: ExamExposeOption;
+};
+
+type ExamConfigAction = {
+  setTime: (time: number) => void;
+  setSortMethod: (sortMethod: CardSortMethod) => void;
+  setExposeOption: (exposeOption: ExamExposeOption) => void;
+  reset: () => void;
+};
+
+type ExamConfigStore = ExamConfigState & ExamConfigAction;
+
+export const MINUITE = 1000 * 60;
+const initialState: ExamConfigState = {
+  time: MINUITE * 30,
+  sortMethod: { name: '기본 순', code: 'SORT_001' },
+  exposeOption: { name: '장절', code: 'EXPOSE_001' },
+};
+
+export const useExamConfigStore = create<ExamConfigStore>()(set => ({
+  ...initialState,
+  setTime: time => set(state => ({ ...state, time: MINUITE * time })),
+  setExposeOption: exposeOption => set(state => ({ ...state, exposeOption })),
+  setSortMethod: sortMethod => set(state => ({ ...state, sortMethod })),
+  reset: () => set(initialState),
+}));

--- a/src/features/exam/type.ts
+++ b/src/features/exam/type.ts
@@ -1,0 +1,5 @@
+import { ApiResult, ArrayElement } from '@apis/custom.types.ts';
+import { getExamExposeOptions } from '@apis/exposeOption.ts';
+
+export type ExamExposeOptions = ApiResult<typeof getExamExposeOptions>;
+export type ExamExposeOption = ArrayElement<ExamExposeOptions>;

--- a/src/pages/home/index.test.tsx
+++ b/src/pages/home/index.test.tsx
@@ -4,4 +4,5 @@ describe('HomePage Test', () => {
   test('renders "홈으로","암송하기","시험보기" links and series tabs', () => {});
   test('when clicks "암송하기" link without selected verses, routing stops and "암송 구절을 선택해주세요." message pops up', () => {});
   test('when clicks "시험보기" link without selected verses, routing stops and "암송 구절을 선택해주세요." message pops up', () => {});
+  test('when clicks "시험보기" link with verses selected, "시험설정" dialog pops up', () => {});
 });

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -3,17 +3,34 @@ import VerseSelect from '@features/verseSelect';
 import { FaHome } from '@react-icons/all-files/fa/FaHome';
 import { useVerseSelectStore } from '@store/verseSelectStore.ts';
 import { useShallow } from 'zustand/react/shallow';
+import ExamConfigModal from '@features/exam/components/examConfigModal';
+import { useExamConfigModalStore } from '@features/exam/store/examConfigModalStore.ts';
+import { useExamConfigStore } from '@features/exam/store/examConfigStore.ts';
 
 function Home() {
   const hasSelectedVerse = useVerseSelectStore(
     useShallow(state => state.hasAnyId),
   );
+  const setExamConfigModalOpen = useExamConfigModalStore(
+    state => state.setIsOpen,
+  );
+  const resetExamConfig = useExamConfigStore(state => state.reset);
 
-  const handleOtherLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleDrillingLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (!hasSelectedVerse()) {
       e.preventDefault();
       alert('암송 구절을 선택해주세요. 😊');
     }
+  };
+
+  const handleExamLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (!hasSelectedVerse()) {
+      alert('암송 구절을 선택해주세요. 😊');
+      return;
+    }
+    resetExamConfig();
+    setExamConfigModalOpen(true);
   };
 
   return (
@@ -30,7 +47,7 @@ function Home() {
             <Link
               to={`/drilling`}
               className='inline-block w-full px-4 py-2.5'
-              onClick={handleOtherLinkClick}
+              onClick={handleDrillingLinkClick}
             >
               암송하기
             </Link>
@@ -39,7 +56,7 @@ function Home() {
             <Link
               to={`/exam`}
               className='inline-block w-full px-4 py-2.5'
-              onClick={handleOtherLinkClick}
+              onClick={handleExamLinkClick}
             >
               시험보기
             </Link>
@@ -52,6 +69,7 @@ function Home() {
         </h1>
         <VerseSelect />
       </div>
+      <ExamConfigModal />
     </div>
   );
 }


### PR DESCRIPTION
# 🎋 작업중인 브랜치 

Feat/#20/exam config

<br/>

# 💡 작업 내용 
> 풀 리퀘스트에 대한 간략한 설명을 여기에 입력해주세요

### 1. 공통 modal 추가 
### 2. 시험설정 modal 추가 


<br/>

# 🔑  변경된 사항 
> 변경된 파일과 그에 대한 간략한 설명을 나열해주세요. 

## 1. 공통 modal 추가 

<br/>

18fa85791aebe559a05a94bfd4a1e2511fb2ab84
- contents를 children으로 전달받는 공통 modal을 추가했습니다. 

<br/>

## 2. 시험설정 modal 추가 

<br/>

c736f1d1b78b0942f87b0580e2b1281ab59622aa, 5b2f7177b212ca4f419061383451be704debe286, 68e57c726d1c736ae35d2667e29e8d32dbcdeae6

- 시험관련 설정 modal과 관련 api, 상태관리를 추가했습니다. 
- 메인페이지에서 "시험보기" 링크와 시험설정 modal을 연결하고, 모달에서 확인버튼 클릭시 시험보기 페이지로 라우팅되도록 했습니다.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/22e58607-0468-4a7e-8aed-c5612f50a3bb" />


<br/>

# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.

Suspense, ErrorBoundary는 기능구현 완료하고 일괄로 적용해보겠습니다. 

<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
